### PR TITLE
Add slice resize on calls to Remove.

### DIFF
--- a/slicelist_test.go
+++ b/slicelist_test.go
@@ -111,6 +111,15 @@ func TestRemove(t *testing.T) {
 			return
 		}
 	}
+
+	// Now we want to check that the resize didn't break the ability to add.
+	for i := 0; i < max; i++ {
+		list.Add(IntElt(i))
+		if list.Len() != i+1 {
+			t.Error("Unable to add after removing all elements.")
+			return
+		}
+	}
 }
 
 func TestGet(t *testing.T) {


### PR DESCRIPTION
Currently, the remove method just removes the element at the given index and shifts the elements down by 1 index. However, the backing slice is never resized, so it is possible for the backing array of the backing slice for the SliceList could become massive even though the length of the backing slice is very small. This changeset adds the functionality to resize the slice when remove is called to make sure we aren't ever holding onto too much memory. 