### PR TITLE
Add SliceContainer

### DIFF
--- a/lists/slice_list.go
+++ b/lists/slice_list.go
@@ -1,37 +1,22 @@
 package listadts
 
 import (
-	"sync"
-
 	adts "github.com/johnsrd7/go-adts"
 )
 
 // SliceList is a simple type that implements the List interface.
 type SliceList struct {
-	backer       []adts.ContainerElement
-	lock         *sync.Mutex
-	threadSafe   bool
-	shrinkFactor float32
+	backer *adts.SliceContainer
 }
 
 // MakeSliceList creates a new non-threadsafe SliceList.
 func MakeSliceList() *SliceList {
-	return &SliceList{[]adts.ContainerElement{}, &sync.Mutex{}, false, 0.25}
+	return &SliceList{adts.MakeSliceContainer()}
 }
 
 // MakeSliceListThreadSafe creates a new threadsafe SliceList.
 func MakeSliceListThreadSafe() *SliceList {
-	return &SliceList{[]adts.ContainerElement{}, &sync.Mutex{}, true, 0.25}
-}
-
-// Cap returns the capacity of the list.
-func (sl *SliceList) Cap() int {
-	if sl.threadSafe {
-		sl.lock.Lock()
-		defer sl.lock.Unlock()
-		return cap(sl.backer)
-	}
-	return cap(sl.backer)
+	return &SliceList{adts.MakeSliceContainerThreadSafe()}
 }
 
 // -------------------------------------------------------
@@ -40,117 +25,33 @@ func (sl *SliceList) Cap() int {
 
 // Len returns the number of elements in the list.
 func (sl *SliceList) Len() int {
-	if sl.threadSafe {
-		sl.lock.Lock()
-		defer sl.lock.Unlock()
-		return len(sl.backer)
-	}
-	return len(sl.backer)
+	return sl.backer.Len()
 }
 
 // IsEmpty returns if the list is empty or not.
 func (sl *SliceList) IsEmpty() bool {
-	return sl.Len() == 0
+	return sl.backer.Len() == 0
 }
 
 // Clear removes all elements from the list.
 func (sl *SliceList) Clear() {
-	if sl.threadSafe {
-		sl.lock.Lock()
-		defer sl.lock.Unlock()
-		sl.backer = []adts.ContainerElement{}
-		return
-	}
-
-	sl.backer = []adts.ContainerElement{}
+	sl.backer.Clear()
 }
 
 // Contains returns true if the given item is in the list.
 func (sl *SliceList) Contains(item adts.ContainerElement) bool {
-	if sl.threadSafe {
-		sl.lock.Lock()
-		defer sl.lock.Unlock()
-		return sl.containsHelper(item)
-	}
-
-	return sl.containsHelper(item)
-}
-
-// containsHelper returns whether the given element is in the list.
-func (sl *SliceList) containsHelper(item adts.ContainerElement) bool {
-	for _, i := range sl.backer {
-		if i.Equals(item) {
-			return true
-		}
-	}
-
-	return false
+	return sl.backer.Contains(item)
 }
 
 // Add returns true if the given element was appended to the end of the list.
 func (sl *SliceList) Add(item adts.ContainerElement) bool {
-	if sl.threadSafe {
-		sl.lock.Lock()
-		defer sl.lock.Unlock()
-		sl.backer = append(sl.backer, item)
-	} else {
-		sl.backer = append(sl.backer, item)
-	}
-
-	return true
+	return sl.backer.Add(item)
 }
 
 // Remove removes the element at the given index and
 // returns whether the removal was successful.
 func (sl *SliceList) Remove(item adts.ContainerElement) bool {
-	if sl.threadSafe {
-		sl.lock.Lock()
-		defer sl.lock.Unlock()
-		idx := sl.findHelper(item)
-		if idx < 0 {
-			return false
-		}
-		sl.removeHelper(idx)
-	} else {
-		idx := sl.findHelper(item)
-		if idx < 0 {
-			return false
-		}
-		sl.removeHelper(idx)
-	}
-
-	return true
-}
-
-// findHelper searches the list for the given element and returns the index
-// of the item in the list. If the item doesn't exist in the list, then -1
-// is returned.
-func (sl *SliceList) findHelper(item adts.ContainerElement) int {
-	for idx, val := range sl.backer {
-		if item.Equals(val) {
-			return idx
-		}
-	}
-
-	return -1
-}
-
-// removeHelper removes the element at the given idx.
-func (sl *SliceList) removeHelper(idx int) {
-	sl.backer = append(sl.backer[:idx], sl.backer[idx+1:]...)
-
-	// We should check to see if we need to resize the slice. We don't
-	// want it to be the case that we added a ton of items then removed
-	// a bunch and now we are still holding onto the large backing array
-	// for the slice.
-	emptyFactor := float32(len(sl.backer)) / float32(cap(sl.backer))
-	if emptyFactor <= sl.shrinkFactor {
-		// Shrink the slice's capacity by 1/2
-		newCap := cap(sl.backer) / 2
-		newBacker := make([]adts.ContainerElement, len(sl.backer), newCap)
-		copy(newBacker, sl.backer)
-		sl.backer = newBacker
-	}
+	return sl.backer.Remove(item)
 }
 
 // -------------------------------------------------------
@@ -159,27 +60,27 @@ func (sl *SliceList) removeHelper(idx int) {
 
 // Get returns the element at the given index.
 func (sl *SliceList) Get(idx int) adts.ContainerElement {
-	if sl.threadSafe {
-		sl.lock.Lock()
-		defer sl.lock.Unlock()
-		return sl.backer[idx]
+	if sl.backer.ThreadSafe {
+		sl.backer.Lock.Lock()
+		defer sl.backer.Lock.Unlock()
+		return sl.backer.Backer[idx]
 	}
 
-	return sl.backer[idx]
+	return sl.backer.Backer[idx]
 }
 
 // Set changes the value at the given index to the given new value
 // and returns the old value that was at the given index.
 func (sl *SliceList) Set(idx int, newVal adts.ContainerElement) adts.ContainerElement {
-	if sl.threadSafe {
-		sl.lock.Lock()
-		defer sl.lock.Unlock()
-		oldVal := sl.backer[idx]
-		sl.backer[idx] = newVal
+	if sl.backer.ThreadSafe {
+		sl.backer.Lock.Lock()
+		defer sl.backer.Lock.Unlock()
+		oldVal := sl.backer.Backer[idx]
+		sl.backer.Backer[idx] = newVal
 		return oldVal
 	}
 
-	oldVal := sl.backer[idx]
-	sl.backer[idx] = newVal
+	oldVal := sl.backer.Backer[idx]
+	sl.backer.Backer[idx] = newVal
 	return oldVal
 }

--- a/lists/slice_list_test.go
+++ b/lists/slice_list_test.go
@@ -1,7 +1,6 @@
 package listadts
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 
@@ -11,14 +10,8 @@ import (
 func TestMakeSliceList(t *testing.T) {
 	list := MakeSliceList()
 
-	if len(list.backer) != 0 {
-		t.Error("Length of empty list should be 0")
-	}
-	if list.threadSafe {
-		t.Error("Threadsafe bool should not be set on default make call.")
-	}
-	if list.lock == nil {
-		t.Error("Lock should not be nil after make call.")
+	if list.backer == nil {
+		t.Error("Backing container should not be nil.")
 	}
 
 	var l List
@@ -37,7 +30,7 @@ func TestSliceListLen(t *testing.T) {
 	list := MakeSliceList()
 
 	for i := 0; i < 50; i++ {
-		list.backer = append(list.backer, adts.IntElt(i))
+		list.Add(adts.IntElt(i))
 
 		if list.Len() != i+1 {
 			t.Errorf("List should have length %d, actual length: %d", i+1, list.Len())
@@ -77,7 +70,7 @@ func TestSliceListClear(t *testing.T) {
 }
 
 func TestSliceListAdd(t *testing.T) {
-	vals := make(map[int][]int) // value -> slice of indices
+	vals := []int{}
 	r := rand.New(rand.NewSource(99))
 
 	list := MakeSliceList()
@@ -85,27 +78,21 @@ func TestSliceListAdd(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		v := r.Int()
 
-		vals[v] = append(vals[v], i)
+		vals = append(vals, v)
 
 		if !list.Add(adts.IntElt(v)) {
 			t.Errorf("Failed to add %d to list\n", v)
 			return
 		}
 
-		if len(list.backer) != i+1 {
-			t.Errorf("List size not correct. Expected: %d, Actual: %d", i+1, len(list.backer))
+		if list.Len() != i+1 {
+			t.Errorf("List size not correct. Expected: %d, Actual: %d", i+1, list.Len())
 			return
 		}
-		for v, idxs := range vals {
-			for _, idx := range idxs {
-				if idx >= len(list.backer) {
-					fmt.Printf("Idx: %d, Len: %d\n", idx, len(list.backer))
-					continue
-				}
-				if !list.backer[idx].Equals(adts.IntElt(v)) {
-					t.Errorf("Add failed to add the value to the proper index | (idx,val) - Expected: (%d, %d), Actual: (%d, %v)",
-						idx, v, idx, list.backer[idx])
-				}
+		for idx, v := range vals {
+			if !list.Get(idx).Equals(adts.IntElt(v)) {
+				t.Errorf("Add failed to add the value to the proper index | (idx,val) - Expected: (%d, %d), Actual: (%d, %v)",
+					idx, v, idx, list.Get(idx))
 			}
 		}
 	}

--- a/slice_container.go
+++ b/slice_container.go
@@ -1,0 +1,138 @@
+package adts
+
+import (
+	"sync"
+)
+
+// SliceContainer is a simple type that implements the Container interface.
+type SliceContainer struct {
+	Backer       []ContainerElement
+	Lock         *sync.Mutex
+	ThreadSafe   bool
+	ShrinkFactor float32
+}
+
+// MakeSliceContainer creates a new non-threadsafe SliceContainer.
+func MakeSliceContainer() *SliceContainer {
+	return &SliceContainer{[]ContainerElement{}, &sync.Mutex{}, false, 0.25}
+}
+
+// MakeSliceContainerThreadSafe creates a new threadsafe SliceContainer.
+func MakeSliceContainerThreadSafe() *SliceContainer {
+	return &SliceContainer{[]ContainerElement{}, &sync.Mutex{}, true, 0.25}
+}
+
+// Len returns the number of elements in the container.
+func (sc *SliceContainer) Len() int {
+	if sc.ThreadSafe {
+		sc.Lock.Lock()
+		defer sc.Lock.Unlock()
+		return len(sc.Backer)
+	}
+	return len(sc.Backer)
+}
+
+// IsEmpty returns if the container is empty or not.
+func (sc *SliceContainer) IsEmpty() bool {
+	return sc.Len() == 0
+}
+
+// Clear removes all elements from the container.
+func (sc *SliceContainer) Clear() {
+	if sc.ThreadSafe {
+		sc.Lock.Lock()
+		defer sc.Lock.Unlock()
+		sc.Backer = []ContainerElement{}
+		return
+	}
+
+	sc.Backer = []ContainerElement{}
+}
+
+// Contains returns true if the given item is in the container.
+func (sc *SliceContainer) Contains(item ContainerElement) bool {
+	if sc.ThreadSafe {
+		sc.Lock.Lock()
+		defer sc.Lock.Unlock()
+		return sc.containsHelper(item)
+	}
+
+	return sc.containsHelper(item)
+}
+
+// containsHelper returns whether the given element is in the container.
+func (sc *SliceContainer) containsHelper(item ContainerElement) bool {
+	for _, i := range sc.Backer {
+		if i.Equals(item) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Add returns true if the given element was appended to the end of the container.
+func (sc *SliceContainer) Add(item ContainerElement) bool {
+	if sc.ThreadSafe {
+		sc.Lock.Lock()
+		defer sc.Lock.Unlock()
+		sc.Backer = append(sc.Backer, item)
+	} else {
+		sc.Backer = append(sc.Backer, item)
+	}
+
+	return true
+}
+
+// Remove removes the element at the given index and
+// returns whether the removal was successful.
+func (sc *SliceContainer) Remove(item ContainerElement) bool {
+	if sc.ThreadSafe {
+		sc.Lock.Lock()
+		defer sc.Lock.Unlock()
+		idx := sc.findHelper(item)
+		if idx < 0 {
+			return false
+		}
+		sc.RemoveAtIndex(idx)
+	} else {
+		idx := sc.findHelper(item)
+		if idx < 0 {
+			return false
+		}
+		sc.RemoveAtIndex(idx)
+	}
+
+	return true
+}
+
+// findHelper searches the list for the given element and returns the index
+// of the item in the container. If the item doesn't exist in the list, then -1
+// is returned.
+func (sc *SliceContainer) findHelper(item ContainerElement) int {
+	for idx, val := range sc.Backer {
+		if item.Equals(val) {
+			return idx
+		}
+	}
+
+	return -1
+}
+
+// RemoveAtIndex removes the element at the given idx.
+func (sc *SliceContainer) RemoveAtIndex(idx int) {
+	sc.Backer = append(sc.Backer[:idx], sc.Backer[idx+1:]...)
+
+	// We should check to see if we need to resize the slice. We don't
+	// want it to be the case that we added a ton of items then removed
+	// a bunch and now we are still holding onto the large backing array
+	// for the slice.
+	emptyFactor := float32(len(sc.Backer)) / float32(cap(sc.Backer))
+	if emptyFactor <= sc.ShrinkFactor {
+		// Shrink the slice's capacity by 1/2
+		newCap := cap(sc.Backer) / 2
+		newBacker := make([]ContainerElement, len(sc.Backer), newCap)
+		copy(newBacker, sc.Backer)
+		sc.Backer = newBacker
+	}
+}

--- a/slice_container_test.go
+++ b/slice_container_test.go
@@ -1,0 +1,168 @@
+package adts
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+func TestMakeSliceContainer(t *testing.T) {
+	container := MakeSliceContainer()
+
+	if len(container.Backer) != 0 {
+		t.Error("Length of empty container should be 0")
+	}
+	if container.ThreadSafe {
+		t.Error("Threadsafe bool should not be set on default make call.")
+	}
+	if container.Lock == nil {
+		t.Error("Lock should not be nil after make call.")
+	}
+
+	var l Container
+	l = MakeSliceContainer()
+
+	if l.Len() != 0 {
+		t.Error("Length of empty container should be 0.")
+	}
+}
+
+// -------------------------------------------------------
+// Test Container Methods
+// -------------------------------------------------------
+
+func TestSliceContainerLen(t *testing.T) {
+	container := MakeSliceContainer()
+
+	for i := 0; i < 50; i++ {
+		container.Backer = append(container.Backer, IntElt(i))
+
+		if container.Len() != i+1 {
+			t.Errorf("Container should have length %d, actual length: %d", i+1, container.Len())
+			return
+		}
+	}
+}
+
+func TestSliceContainerIsEmpty(t *testing.T) {
+	container := MakeSliceContainer()
+
+	if !container.IsEmpty() {
+		t.Errorf("Empty container should return true for IsEmpty.\n")
+	}
+
+	container.Add(IntElt(0))
+	if container.IsEmpty() {
+		t.Errorf("Container with 1 element should not return true for IsEmpty.\n")
+	}
+}
+
+func TestSliceContainerClear(t *testing.T) {
+	container := MakeSliceContainer()
+
+	for i := 0; i < 100; i++ {
+		container.Add(IntElt(i))
+	}
+
+	if container.Len() != 100 {
+		t.Errorf("Check Add/Len method, should have length of 100 after 100 adds.\n")
+	}
+
+	container.Clear()
+	if !container.IsEmpty() {
+		t.Errorf("Container should be empty after call to Clear.\n")
+	}
+}
+
+func TestSliceContainerAdd(t *testing.T) {
+	vals := make(map[int][]int) // value -> slice of indices
+	r := rand.New(rand.NewSource(99))
+
+	container := MakeSliceContainer()
+
+	for i := 0; i < 1000; i++ {
+		v := r.Int()
+
+		vals[v] = append(vals[v], i)
+
+		if !container.Add(IntElt(v)) {
+			t.Errorf("Failed to add %d to container\n", v)
+			return
+		}
+
+		if len(container.Backer) != i+1 {
+			t.Errorf("Container size not correct. Expected: %d, Actual: %d", i+1, len(container.Backer))
+			return
+		}
+		for v, idxs := range vals {
+			for _, idx := range idxs {
+				if idx >= len(container.Backer) {
+					fmt.Printf("Idx: %d, Len: %d\n", idx, len(container.Backer))
+					continue
+				}
+				if !container.Backer[idx].Equals(IntElt(v)) {
+					t.Errorf("Add failed to add the value to the proper index | (idx,val) - Expected: (%d, %d), Actual: (%d, %v)",
+						idx, v, idx, container.Backer[idx])
+				}
+			}
+		}
+	}
+}
+
+func TestSliceContainerContains(t *testing.T) {
+	vals := make(map[int]bool)
+	r := rand.New(rand.NewSource(99))
+
+	container := MakeSliceContainer()
+
+	for i := 0; i < 1000; i++ {
+		v := r.Int()
+
+		vals[v] = true
+
+		container.Add(IntElt(v))
+
+		for v := range vals {
+			if !container.Contains(IntElt(v)) {
+				t.Errorf("Contains failed to find the value (%d) in the container.", v)
+			}
+		}
+	}
+}
+
+func TestSliceContainerRemove(t *testing.T) {
+	max := 1000
+
+	container := MakeSliceContainer()
+	for i := 0; i < max; i++ {
+		container.Add(IntElt(i))
+	}
+
+	for i := 0; i < max; i++ {
+		idx := rand.Int31n(int32(max - i))
+		val := container.Backer[idx]
+		if !container.Remove(val) {
+			t.Errorf("Failed to remove index %d from container.", idx)
+			return
+		}
+
+		if container.Len() != max-1-i {
+			t.Errorf("Expected length: %d, Actual length: %d", max-1-i, container.Len())
+			return
+		}
+
+		if container.Contains(val) {
+			t.Errorf("Value %v was not actually removed from container.", val)
+			return
+		}
+	}
+
+	// Now we want to check that the resize didn't break the ability to add.
+	for i := 0; i < max; i++ {
+		container.Add(IntElt(i))
+		if container.Len() != i+1 {
+			t.Error("Unable to add after removing all elements.")
+			return
+		}
+	}
+}

--- a/stacks/slice_stack_test.go
+++ b/stacks/slice_stack_test.go
@@ -10,14 +10,8 @@ import (
 func TestMakeSliceStack(t *testing.T) {
 	stack := MakeSliceStack()
 
-	if len(stack.backer) != 0 {
-		t.Error("Length of empty stack should be 0")
-	}
-	if stack.threadSafe {
-		t.Error("Threadsafe bool should not be set on default make call.")
-	}
-	if stack.lock == nil {
-		t.Error("Lock should not be nil after make call.")
+	if stack.backer == nil {
+		t.Error("Backing Container should not be nil after make call.")
 	}
 
 	var s Stack
@@ -36,7 +30,7 @@ func TestSliceStackLen(t *testing.T) {
 	stack := MakeSliceStack()
 
 	for i := 0; i < 50; i++ {
-		stack.backer = append(stack.backer, adts.IntElt(i))
+		stack.Add(adts.IntElt(i))
 
 		if stack.Len() != i+1 {
 			t.Errorf("Stack should have length %d, actual length: %d", i+1, stack.Len())
@@ -91,14 +85,14 @@ func TestSliceStackAdd(t *testing.T) {
 			return
 		}
 
-		if len(stack.backer) != i+1 {
-			t.Errorf("Stack size not correct. Expected: %d, Actual: %d", i+1, len(stack.backer))
+		if stack.Len() != i+1 {
+			t.Errorf("Stack size not correct. Expected: %d, Actual: %d", i+1, stack.Len())
 			return
 		}
 		for idx, v := range vals {
-			if !stack.backer[idx].Equals(adts.IntElt(v)) {
+			if !stack.backer.Backer[idx].Equals(adts.IntElt(v)) {
 				t.Errorf("Add failed to add the value to the proper index | (idx,val) - Expected: (%d, %d), Actual: (%d, %v)",
-					idx, v, idx, stack.backer[idx])
+					idx, v, idx, stack.backer.Backer[idx])
 			}
 
 		}
@@ -136,7 +130,7 @@ func TestSliceStackRemove(t *testing.T) {
 
 	for i := 0; i < max; i++ {
 		idx := rand.Int31n(int32(max - i))
-		val := stack.backer[idx]
+		val := stack.backer.Backer[idx]
 		if !stack.Remove(val) {
 			t.Errorf("Failed to remove index %d from list.", idx)
 			return
@@ -185,7 +179,7 @@ func TestSliceStackPush(t *testing.T) {
 			return
 		}
 		for idx, exp := range expected {
-			act := stack.backer[idx]
+			act := stack.backer.Backer[idx]
 			if !act.Equals(adts.IntElt(exp)) {
 				t.Errorf("Stack order was ruined by push. (idx, val) - Expected: (%d, %d), Actual: (%d, %v)",
 					idx, exp, idx, act)


### PR DESCRIPTION
Refactor code since both SliceList and SliceStack have similar behaviours for the Container methods. This changeset refactors that code into a SliceContainer class that now the SliceList and SliceStack uses as a backer. All tests pass and all code passes `go vet` and `go lint`.