### PR TITLE
Add ListStack impl for Stack ADT.

### DIFF
--- a/stacks/list_stack.go
+++ b/stacks/list_stack.go
@@ -1,0 +1,156 @@
+package stackadts
+
+import (
+	"container/list"
+	"sync"
+
+	adts "github.com/johnsrd7/go-adts"
+)
+
+// ListStack is a simple type that implements the Stack interface (both threadsafe and not).
+type ListStack struct {
+	backer     *list.List
+	lock       *sync.Mutex
+	threadSafe bool
+}
+
+// MakeListStack creates a non-threadsafe ListStack
+func MakeListStack() *ListStack {
+	return &ListStack{list.New(), &sync.Mutex{}, false}
+}
+
+// MakeListStackThreadSafe creates a threadsafe ListStack
+func MakeListStackThreadSafe() *ListStack {
+	return &ListStack{list.New(), &sync.Mutex{}, true}
+}
+
+// -------------------------------------------------------
+// Container Methods
+// -------------------------------------------------------
+
+// Len returns the number of elements in the stack.
+func (ls *ListStack) Len() int {
+	if ls.threadSafe {
+		ls.lock.Lock()
+		defer ls.lock.Unlock()
+		return ls.Len()
+	}
+
+	return ls.Len()
+}
+
+// IsEmpty returns if the stack is empty or not.
+func (ls *ListStack) IsEmpty() bool {
+	return ls.backer.Len() == 0
+}
+
+// Clear removes all elements from the stack.
+func (ls *ListStack) Clear() {
+	if ls.threadSafe {
+		ls.lock.Lock()
+		defer ls.lock.Unlock()
+		ls.backer.Init()
+		return
+	}
+
+	ls.backer.Init()
+}
+
+// Contains returns true if the given item is in the stack.
+func (ls *ListStack) Contains(item adts.ContainerElement) bool {
+	if ls.threadSafe {
+		ls.lock.Lock()
+		defer ls.lock.Unlock()
+		return ls.containsHelper(item)
+	}
+
+	return ls.containsHelper(item)
+}
+
+// containsHelper checks the list for the given element (in a non-threadsafe way).
+func (ls *ListStack) containsHelper(item adts.ContainerElement) bool {
+	for tmp := ls.backer.Front(); tmp != nil; tmp = tmp.Next() {
+		if v, ok := tmp.Value.(adts.ContainerElement); ok {
+			if v.Equals(item) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// Add returns true if the given element was added to the top of the stack.
+func (ls *ListStack) Add(item adts.ContainerElement) bool {
+	if ls.threadSafe {
+		ls.lock.Lock()
+		defer ls.lock.Unlock()
+		return ls.backer.PushFront(item) != nil
+	}
+
+	return ls.backer.PushFront(item) != nil
+}
+
+// Remove is a non-valid function for the Stack interface. It is only provided here
+// as a means to satisfy the Container interface. See Pop function for Stack to remove
+// elements from the stack.
+func (ls *ListStack) Remove(item adts.ContainerElement) bool {
+	if ls.threadSafe {
+		ls.lock.Lock()
+		defer ls.lock.Unlock()
+		return ls.removeHelper(item)
+	}
+
+	return ls.removeHelper(item)
+}
+
+func (ls *ListStack) removeHelper(item adts.ContainerElement) bool {
+	for tmp := ls.backer.Front(); tmp != nil; tmp = tmp.Next() {
+		if v, ok := tmp.Value.(adts.ContainerElement); ok {
+			if v.Equals(item) {
+				removed, ok := ls.backer.Remove(tmp).(adts.ContainerElement)
+				return ok && removed.Equals(item)
+			}
+		}
+	}
+
+	return false
+}
+
+// -------------------------------------------------------
+// Stack Methods
+// -------------------------------------------------------
+
+// Push pushes the given element onto the top of the stack.
+func (ls *ListStack) Push(item adts.ContainerElement) {
+	if !ls.Add(item) {
+		panic("Unable to push the given item to the top of the stack.")
+	}
+}
+
+// Pop removes the top element from the stack and returns the element.
+func (ls *ListStack) Pop() adts.ContainerElement {
+	if ls.threadSafe {
+		ls.lock.Lock()
+		defer ls.lock.Unlock()
+		return ls.popHelper()
+	}
+
+	return ls.popHelper()
+}
+
+// popHelper removes the element from the front of the list and returns the element.
+func (ls *ListStack) popHelper() adts.ContainerElement {
+	// Have to use list.List's Len function since we might already
+	// be inside a lock and we don't want to deadlock.
+	if ls.backer.Len() == 0 {
+		panic("Can't pop from an empty stack.")
+	}
+
+	if lastElt, ok := ls.backer.Front().Value.(adts.ContainerElement); ok {
+		ls.backer.Remove(ls.backer.Front())
+		return lastElt
+	}
+
+	panic("Unable to pop element from top of stack.")
+}


### PR DESCRIPTION
This changeset adds the ListStack implementation for the Stack ADT. There are no tests for this yet so use with caution. Build passes as well as go vet and golint. 